### PR TITLE
Fixed sendMessage

### DIFF
--- a/INextionWidget.cpp
+++ b/INextionWidget.cpp
@@ -101,8 +101,9 @@ size_t INextionWidget::getStringProperty(char *propertyName, char *value,
 
 bool INextionWidget::sendCommand(char *commandStr, bool checkComplete)
 {
-  if (m_pageID != m_nextion.getCurrentPage())
-    return false;
+  // Removed: this prevent to send commands to objects in other pages
+  //if (m_pageID != m_nextion.getCurrentPage()) 
+  //  return false;
 
   m_nextion.sendCommand(commandStr);
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Avaliable through the library manager of the Arduio IDE as `NeoNextion`.
 
 ## New features
 
+Added by Viktor1970: removed a check in sendMessage method, that prevents to control objects in other pages.
+                     Now the page's show() method it's working.
+
+
+
 I don't use Nextion displays in my projects anymore so this library may not
 allow all the features in the latest display firmware to be used. However
 I still own a few of them and am happy to work on adding new functionality


### PR DESCRIPTION
Removed a check in sendMessage method, that prevents to control objects in other pages.