### PR TITLE
Added wake-up event managing

### DIFF
--- a/INextionWidget.cpp
+++ b/INextionWidget.cpp
@@ -101,8 +101,9 @@ size_t INextionWidget::getStringProperty(char *propertyName, char *value,
 
 bool INextionWidget::sendCommand(char *commandStr, bool checkComplete)
 {
-  if (m_pageID != m_nextion.getCurrentPage())
-    return false;
+  // Removed: this prevent to send commands to objects in other pages
+  //if (m_pageID != m_nextion.getCurrentPage()) 
+  //  return false;
 
   m_nextion.sendCommand(commandStr);
 

--- a/INextionWidget.h
+++ b/INextionWidget.h
@@ -26,13 +26,14 @@ public:
   bool setStringProperty(char *propertyName, char *value);
   size_t getStringProperty(char *propertyName, char *value, size_t len);
 
-protected:
+  uint8_t m_componentID; //!< Component ID of this widget
+  uint8_t m_pageID;      //!< ID of page this widget is on
+  
+  protected:
   bool sendCommand(char *commandStr, bool checkComplete = true);
 
 protected:
   Nextion &m_nextion;    //!< Reference to the Nextion driver
-  uint8_t m_pageID;      //!< ID of page this widget is on
-  uint8_t m_componentID; //!< Component ID of this widget
   const char *m_name;    //!< Name of this widget
 };
 

--- a/INextionWidget.h
+++ b/INextionWidget.h
@@ -26,8 +26,6 @@ public:
   bool setStringProperty(char *propertyName, char *value);
   size_t getStringProperty(char *propertyName, char *value, size_t len);
 
-  uint8_t m_componentID; //!< Component ID of this widget
-  uint8_t m_pageID;      //!< ID of page this widget is on
   
   protected:
   bool sendCommand(char *commandStr, bool checkComplete = true);
@@ -35,6 +33,8 @@ public:
 protected:
   Nextion &m_nextion;    //!< Reference to the Nextion driver
   const char *m_name;    //!< Name of this widget
+  uint8_t m_componentID; //!< Component ID of this widget
+  uint8_t m_pageID;      //!< ID of page this widget is on
 };
 
 #endif

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -58,7 +58,7 @@ void Nextion::poll()
         for (i = 1; i < 7; i++)
           buffer[i] = m_serialPort.read();
         buffer[i] = 0x00;
-		Serial.println(String(buffer[0])+" "+String(buffer[1])+" "+String(buffer[2])+" "+String(buffer[3])+" "+String(buffer[4])+" "+String(buffer[5])+" "+String(buffer[6]));
+		//Serial.println(String(buffer[0])+" "+String(buffer[1])+" "+String(buffer[2])+" "+String(buffer[3])+" "+String(buffer[4])+" "+String(buffer[5])+" "+String(buffer[6]));
         if (buffer[4] == 0xFF && buffer[5] == 0xFF && buffer[6] == 0xFF)
         {
           ITouchableListItem *item = m_touchableList;

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -23,6 +23,7 @@ Nextion::Nextion(Stream &stream, bool flushSerialBeforeTx)
  */
 bool Nextion::init()
 {
+  WakeEvent=false;
   sendCommand("");
 
   sendCommand("bkcmd=1");
@@ -70,20 +71,41 @@ void Nextion::poll()
         }
       }
     }
-#ifdef NEX_SS	
-	else if(c == NEX_RET_EVENT_SLEEP_POSITION_HEAD)
-	{
-	 delay(10);	
-     ITouchableListItem *item = m_touchableList;
-     while (item != NULL)
-     {
-      //item->item->processEvent(buffer[1], buffer[2], buffer[3]);
-      if(item->item->m_componentID==NEX_SS_COMP&&item->item->m_pageID==NEX_SS_PAGE) {item->item->processEvent(NEX_SS_PAGE,NEX_SS_COMP,NEX_EVENT_POP); break;}
-      else item = item->next;
-     }
-	}
-#endif
+
+	if(WakeEvent)
+  	 if(c == NEX_RET_EVENT_SLEEP_POSITION_HEAD)
+	 {
+ 	  delay(10);	
+      ITouchableListItem *item = m_touchableList;
+      while (item != NULL)
+      {
+      // Serial.println(item->item->getComponentID());
+	   if(item->item->getComponentID()==WakeComponentID&&item->item->getPageID()==WakePageID) {item->item->processEvent(WakePageID, WakeComponentID, NEX_EVENT_POP); break;}
+        else item = item->next;
+      }
+	 }
+
   }
+}
+
+/*!
+ * \brief Do not handle Wake event.
+ */
+void Nextion::DeActivateWakeEvent()
+{
+  WakeEvent=false;
+}
+
+/*!
+ * \brief Set the callback to call when Wake event occours (the component needs a callback attached).
+ * \param page_id In which page the component is
+ * \param component_id The component ID 
+ */
+void Nextion::ActivateWakeEvent(uint8_t page_id, uint8_t component_id)
+{
+  WakeEvent=true;
+  WakePageID=page_id;
+  WakeComponentID=component_id;
 }
 
 /*!

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -43,7 +43,9 @@ void Nextion::poll()
   {
     char c = m_serialPort.read();
 
-    if (c == NEX_RET_EVENT_TOUCH_HEAD)
+	//Serial.print("Ret:"); Serial.println((byte)c);
+	
+    if (c == NEX_RET_EVENT_TOUCH_HEAD )
     {
       delay(10);
 
@@ -56,7 +58,7 @@ void Nextion::poll()
         for (i = 1; i < 7; i++)
           buffer[i] = m_serialPort.read();
         buffer[i] = 0x00;
-
+		Serial.println(String(buffer[0])+" "+String(buffer[1])+" "+String(buffer[2])+" "+String(buffer[3])+" "+String(buffer[4])+" "+String(buffer[5])+" "+String(buffer[6]));
         if (buffer[4] == 0xFF && buffer[5] == 0xFF && buffer[6] == 0xFF)
         {
           ITouchableListItem *item = m_touchableList;
@@ -68,6 +70,17 @@ void Nextion::poll()
         }
       }
     }
+	else if(c == NEX_RET_EVENT_SLEEP_POSITION_HEAD)
+	{
+	 delay(10);	
+     ITouchableListItem *item = m_touchableList;
+     while (item != NULL)
+     {
+      //item->item->processEvent(buffer[1], buffer[2], buffer[3]);
+      if(item->item->m_componentID==NEX_SS_COMP&&item->item->m_pageID==NEX_SS_PAGE) {item->item->processEvent(NEX_SS_PAGE,NEX_SS_COMP,NEX_EVENT_POP); break;}
+      else item = item->next;
+     }
+	}
   }
 }
 
@@ -239,9 +252,10 @@ bool Nextion::drawStr(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
 {
   size_t commandLen = 65 + strlen(str);
   char commandBuffer[commandLen];
-  snprintf(commandBuffer, commandLen, "xstr %d,%d,%d,%d,%d,%ld,%ld,%d,%d,%d,%s",
+  snprintf(commandBuffer, commandLen, "xstr %d,%d,%d,%d,%d,%ld,%ld,%d,%d,%d,\"%s\"",
            x, y, w, h, fontID, fgColour, bgColour, xCentre, yCentre, bgType,
            str);
+  //Serial.println(commandBuffer);
   sendCommand(commandBuffer);
   return checkCommandComplete();
 }

--- a/Nextion.h
+++ b/Nextion.h
@@ -67,12 +67,17 @@ public:
   bool checkCommandComplete();
   bool receiveNumber(uint32_t *number);
   size_t receiveString(char *buffer, size_t len);
+  
+  void ActivateWakeEvent(uint8_t page_id, uint8_t component_id);
+  void DeActivateWakeEvent();
 
 private:
   Stream &m_serialPort;       //!< Serial port device is attached to
   uint32_t m_timeout;         //!< Serial communication timeout in ms
   bool m_flushSerialBeforeTx; //!< Flush serial port before transmission
   ITouchableListItem *m_touchableList; //!< LInked list of INextionTouchable
+  bool WakeEvent;
+  uint8_t WakePageID, WakeComponentID;
 };
 
 #endif

--- a/NextionTypes.h
+++ b/NextionTypes.h
@@ -4,10 +4,6 @@
 #define __NEONEXTION_NEXTIONTYPES
 
 
-#define NEX_SS true		//The code supports Screen Saver (using sleep) mode?
-#define NEX_SS_COMP 1	//Touching that component ID will activare event to exit Screen Saver mode (event attached will be called)
-#define NEX_SS_PAGE 0	//The page in which component is
-
 
 /*!
  * \enum NextionValue

--- a/NextionTypes.h
+++ b/NextionTypes.h
@@ -7,6 +7,11 @@
  * \enum NextionValue
  * \brief Values used in messages.
  */
+ 
+ #define NEX_SS_PAGE 0
+ #define NEX_SS_COMP 1
+  
+ 
 enum NextionValue
 {
   NEX_RET_CMD_FINISHED = (0x01),

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Avaliable through the library manager of the Arduio IDE as `NeoNextion`.
 
 ## New features
 
+Added by Viktor1970: removed a check in sendMessage method, that prevents to control objects in other pages.
+                     Now the page's show() method it's working.
+
+
+
 I don't use Nextion displays in my projects anymore so this library may not
 allow all the features in the latest display firmware to be used. However
 I still own a few of them and am happy to work on adding new functionality

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Avaliable through the library manager of the Arduio IDE as `NeoNextion`.
 ## New features
 
 Added by Viktor1970: 
-- added the capability of managing a wake event in a defined page and component ID, so a callback function can be called.
 - removed a check in sendMessage method, that prevents to control objects in other pages.  Now the page's show() method it's working.
 
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ cleaner, more user friendly and with a bit of luck, faster.
 
 Avaliable through the library manager of the Arduio IDE as `NeoNextion`.
 
+## New features
+
+I don't use Nextion displays in my projects anymore so this library may not
+allow all the features in the latest display firmware to be used. However
+I still own a few of them and am happy to work on adding new functionality
+if it is desired.
+
+If you find a feature that is missing that you want implemented let me know
+and I'll look at adding it for you.
+
 ## Links
 
 - Repository: https://github.com/DanNixon/NeoNextion

--- a/README.md
+++ b/README.md
@@ -13,21 +13,13 @@ Avaliable through the library manager of the Arduio IDE as `NeoNextion`.
 
 ## New features
 
-Added by Viktor1970: removed a check in sendMessage method, that prevents to control objects in other pages.
-                     Now the page's show() method it's working.
+Added by Viktor1970: 
+- added the capability of managing a wake event in a defined page and component ID, so a callback function can be called.
+- removed a check in sendMessage method, that prevents to control objects in other pages.  Now the page's show() method it's working.
 
-
-
-I don't use Nextion displays in my projects anymore so this library may not
-allow all the features in the latest display firmware to be used. However
-I still own a few of them and am happy to work on adding new functionality
-if it is desired.
-
-If you find a feature that is missing that you want implemented let me know
-and I'll look at adding it for you.
 
 ## Links
 
-- Repository: https://github.com/DanNixon/NeoNextion
+- Original Repository: https://github.com/DanNixon/NeoNextion
 - Travis CI: https://travis-ci.org/DanNixon/NeoNextion
 - Documentation: https://dannixon.github.io/NeoNextion


### PR DESCRIPTION
I added 2 methods to Nextion.h/.cpp:

`ActivateWakeEvent(uint8_t page_id, uint8_t component_id);`
This method permits to execute a callback handler attached to **component_id** in **page_id** when the display wakes up after sleep.

`DeActivateWakeEvent();`
This method stops to execute callback described above (so wake-up after sleep send no event to code).