### PR TITLE
Adding ESP32 platform type to library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -20,5 +20,5 @@
     "url": "http://www.dan-nixon.com"
   },
   "frameworks": "arduino",
-  "platforms": ["atmelavr", "atmelsam", "espressif", "espressif32"
+  "platforms": ["atmelavr", "atmelsam", "espressif", "espressif32"]
 }

--- a/library.json
+++ b/library.json
@@ -20,5 +20,5 @@
     "url": "http://www.dan-nixon.com"
   },
   "frameworks": "arduino",
-  "platforms": ["atmelavr", "atmelsam", "espressif"]
+  "platforms": ["atmelavr", "atmelsam", "espressif", "espressif32"
 }


### PR DESCRIPTION
ESP32 uses a different platform type and this library is not usable in PlatformIO by default.